### PR TITLE
Add react routing

### DIFF
--- a/client/dist/index.html
+++ b/client/dist/index.html
@@ -9,16 +9,10 @@
 </head>
 
 <body>
-  <div id="app"></div>
+  <div id="descriptions"></div>
   <script src="https://unpkg.com/react@16/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js" crossorigin></script>
   <script src="bundle.js"></script>
-  <script>
-    ReactDOM.render(
-      React.createElement(Test, null),
-      document.getElementById('app')
-    );
-  </script>
 </body>
 
 </html>

--- a/client/src/__tests__/Entry.test.js
+++ b/client/src/__tests__/Entry.test.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import Entry from '../components/Entry.jsx';
+import { shallow, mount } from 'enzyme';
+
+describe('Entry component', () => {
+  it('renders static files', () => {
+    const wrapper = shallow(<Entry match={ {'params' : { 'id': 12 } } } />);
+    const header = <h1>descriptions</h1>;
+    expect(wrapper.contains(header)).toEqual(true);
+    const checker = <div>welcome to bundle 12</div>;
+    expect(wrapper.contains(checker)).toEqual(true);
+  });
+
+  it('renders the 12th page when sent to /12', () => {
+    const wrapper = shallow(<Entry match={ {'params' : { 'id': 12 } } } />);
+    const checker = <div>welcome to bundle 12</div>;
+    expect(wrapper.contains(checker)).toEqual(true);
+  });
+})
+

--- a/client/src/__tests__/Home.test.js
+++ b/client/src/__tests__/Home.test.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import Home from '../components/Home.jsx';
+import { shallow, mount } from 'enzyme';
+
+it('renders the home page correctly', () => {
+  const wrapper = shallow(<Home />);
+  const header = <h1>enter an id from 1 - 100</h1>;
+  expect(wrapper.contains(header)).toEqual(true);
+});

--- a/client/src/components/Entry.jsx
+++ b/client/src/components/Entry.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import axios from 'axios';
 
 class Entry extends React.Component {
   constructor(props) {
@@ -20,7 +21,7 @@ class Entry extends React.Component {
   render () {
     return (<div>
       <h1>descriptions</h1>
-      <div>{(this.state.online) ? 'we\'re online' : 'we\'re offline'}</div>
+      <div>welcome to bundle {this.props.match.params.id}</div>
       <div className="blurb">
         Get the *bundle name*, so that you can play your way through *tier 2 game name*, *highest tier game name*, *second tier 2 game name*, plus several more. Even better, your payment will go toward *charities for this bundle*.
       </div>
@@ -31,4 +32,4 @@ class Entry extends React.Component {
   }
 }
 
-ReactDOM.render(<Entry />, document.getElementById('descriptions'));
+export default Entry;

--- a/client/src/components/Home.jsx
+++ b/client/src/components/Home.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Home = () => (
+  <div>
+    <h1>enter an id from 1 - 100</h1>
+  </div>
+)
+
+export default Home;

--- a/client/src/components/Main.jsx
+++ b/client/src/components/Main.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Switch, Route } from 'react-router-dom';
+import { Switch, Route, Redirect } from 'react-router-dom';
 import Entry from './Entry.jsx';
 import Home from './Home.jsx';
 
@@ -13,6 +13,7 @@ class Main extends Component {
       <main>
         <Switch>
           <Route exact path='/' component={Home} />
+          {/* <Redirect exact from='/' to='/1' /> */}
           <Route path='/:id' component={Entry} />
         </Switch>
       </main>

--- a/client/src/components/Main.jsx
+++ b/client/src/components/Main.jsx
@@ -1,0 +1,23 @@
+import React, { Component } from 'react';
+import { Switch, Route } from 'react-router-dom';
+import Entry from './Entry.jsx';
+import Home from './Home.jsx';
+
+class Main extends Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <main>
+        <Switch>
+          <Route exact path='/' component={Home} />
+          <Route path='/:id' component={Entry} />
+        </Switch>
+      </main>
+    );
+  }
+}
+
+export default Main;

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -1,22 +1,10 @@
 import React, { Component } from 'react';
-import ReactDOM from 'react-dom';
+import { render } from 'react-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
+import Main from './components/Main.jsx';
 
-class Test extends Component {
-  state = {
-    online: true,
-  }
-
-  render() {
-    const { online } = this.state;
-
-    return (
-      <div>
-        <h1>descriptions</h1>
-      </div>
-    );
-  }
-};
-
-ReactDOM.render(<Test />, document.getElementById('descriptions'));
-
-export default Test;
+render((
+  <Router>
+    <Main />
+  </Router>
+), document.getElementById('descriptions'));

--- a/client/src/index.test.js
+++ b/client/src/index.test.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import Test from './index';
-import { shallow, mount } from 'enzyme';
-
-it('renders correctly', () => {
-  const wrapper = shallow(<Test />);
-  const header = <h1>descriptions</h1>;
-  expect(wrapper.contains(header)).toEqual(true);
-});

--- a/server/app.js
+++ b/server/app.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const db = require('../db/index');
 const morgan = require('morgan');
+const path = require('path');
 const Bundles = require('../db/models/bundles.model');
 
 const app = express();
@@ -35,6 +36,10 @@ app.get('/bundleInfo/:bundleId', (req, res) => {
   .catch((err) => {
     res.status(500).send('something went wrong on our end; wait a bit & try again');
   });
+});
+
+app.get('*', (req,res) =>{
+  res.sendFile(path.join(__dirname + '/../client/dist/index.html'));
 });
 
 module.exports = app;


### PR DESCRIPTION
I've added a home page that asks users to add a bundle ID 1 - 100 and if they enter a working bundle ID, it will take them to the new Entry page. The Main component acts as my switchboard with my top level index.jsx holding just a render invocation now. 

I've updated the server to handle all non-delineated routes through the bundle, thus passing the react routes into the server as well.

I've also split up my client tests and added new ones to reflect the updated component structure and responsive routing.