### PR TITLE
Add countdown clock

### DIFF
--- a/client/src/components/Clock.jsx
+++ b/client/src/components/Clock.jsx
@@ -1,0 +1,36 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import { getSecondsTo, convertSeconds } from '../../../project-utils/clock-utils';
+
+const Clock = (props) => {
+
+  const [secondsTotal, setSecondsTotal] = useState(getSecondsTo(props.countdown));
+
+  useEffect(() => {
+    const config = {
+      url: `http://localhost:3663/bundleInfo/${props.id}`,
+    }
+    if (props.id >= 1 && props.id <= 100) {
+      axios(config)
+      .then(({ data }) => {
+        if (data) {
+          setSecondsTotal(getSecondsTo(data.timesUp));
+        }
+      })
+      .catch((err) => {
+        console.log('err: ', err);
+      });
+    }
+  }, []);
+
+  return (
+    <div>
+      <div className="daysLeft">{daysLeft} days left</div>
+      <div className="hoursLeft">{hoursLeft} hours left</div>
+      <div className="minutesLeft">{minutesLeft} minutes left</div>
+      <div className="secondsLeft">{secondsLeft} seconds left</div>
+    </div>
+  );
+};
+
+export default Clock;


### PR DESCRIPTION
This sets up the countdown clock. Using the clock helpers and the API, we get a total of seconds to a certain date, then render that in a days, hours, minutes, seconds format. The logic to turn that seconds total into will be the next PR.